### PR TITLE
Parse as XML, render CDATA

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "html": "0.0.7",
-    "htmlparser2": "",
+    "htmlparser2": "^3.8.3",
     "kramed": "fchasen/kramed#autoIds",
     "optparse": "1.0.4",
     "string": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "htmlbook",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Markdown to HTMLBook converter",
   "main": "./htmlbook.js",
   "bin": {

--- a/spec/documents/mixins.md
+++ b/spec/documents/mixins.md
@@ -4,4 +4,4 @@
 
 <a name="anchor"></a>
 
-<input type="text">
+<input type="text"/>

--- a/spec/htmlbook_spec.js
+++ b/spec/htmlbook_spec.js
@@ -95,4 +95,9 @@ describe("htmlbook", function () {
   });
 
   // it("should throw an error when no title present in complete mode.")
+
+  it("should handle CDATA", function (done) {
+    expect(htmlbook("<pre><![CDATA[ </body> ]]></pre>").parse()).toEqual("<pre><![CDATA[ </body> ]]></pre>");
+    done();
+  });
 });


### PR DESCRIPTION
Sets htmlparser2 to 'xmlMode' to parse any tags found in markdown as XML
This is needed to handle cdata as a type and not just a comment but also the resulting HTMLbook needs to be valid xhtml as well.

Renders CDATA nodes and does not escape their text.

Fixed tests that used html input instead of xhtml.