### PR TITLE
using console.log instead of sys

### DIFF
--- a/bin/htmlbook
+++ b/bin/htmlbook
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
-var sys = require('sys'),
-  fs = require('fs'),
+var fs = require('fs'),
   optparse = require('optparse'),
   path = require('path'),
   htmlbook = require('../htmlbook'),
@@ -50,7 +49,7 @@ parser.on('output', function (name, value) {
 })
 
 parser.on('help', function() {
-  sys.puts(parser.toString());
+  console.log(parser.toString());
 });
 
 parser.parse(process.argv);
@@ -58,7 +57,7 @@ parser.parse(process.argv);
 if (source_path) {
   fs.readFile(source_path, 'utf8', function (err, data) {
     if (err) {
-      sys.puts(err);
+      console.log(err);
       process.exit(1);
     }
 
@@ -67,7 +66,7 @@ if (source_path) {
     if (output_path) {
       fs.writeFile(output_path, result);
     } else {
-      sys.puts(result);
+      console.log(result);
     }
   });
 } else {
@@ -78,7 +77,7 @@ if (source_path) {
     if (output_path) {
       fs.writeFile(output_path, result);
     } else {
-      sys.puts(result);
+      console.log(result);
     }
   }
 }

--- a/htmlbook.js
+++ b/htmlbook.js
@@ -1,5 +1,4 @@
-var sys = require('sys'),
-  fs = require('fs'),
+var fs = require('fs'),
   util = require('util'),
   _ = require('underscore'),
   htmlparser = require('htmlparser2'),


### PR DESCRIPTION
Using `htmlbook` gives this warning:

```
(node) sys is deprecated. Use util instead
```

I switched all `sys` calls to `console.log`.
